### PR TITLE
reduce maxTokens for glm-4-9b-chat to fit 50GB GPU

### DIFF
--- a/models/zhipuai/glm-4-9b-chat/metadata.yaml
+++ b/models/zhipuai/glm-4-9b-chat/metadata.yaml
@@ -6,7 +6,9 @@ spec:
   config:
     maxTokens: 128000
   deployments:
-  - customRuntimeArgs: []
+  - customRuntimeArgs:
+      - --max-num-batched-tokens=32768 # Reduce maxTokens from 128k to 32k to fit 50GB GPU and avoid OOM
+      - --max-model-len=32768          # Align max-model-len with max-num-batched-tokens for stable inference
     resourceRequirements:
       cpu: 4
       gpuCount: 1


### PR DESCRIPTION
part of https://github.com/BaizeAI/modelhub/issues/44


The default 128k maxTokens causes OOM on 50GB GPUs for long-context inference.

https://huggingface.co/zai-org/glm-4-9b-chat/blob/main/generation_config.json

<img width="790" height="435" alt="image" src="https://github.com/user-attachments/assets/77bdb900-07e1-443c-abab-915edb646bcf" />


